### PR TITLE
Remove Harmony dependancy 

### DIFF
--- a/javascript_features.gemspec
+++ b/javascript_features.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.summary = 'Structured, unobtrusive JavaScript for Rails applications'
 
   s.add_dependency('jsmin')
-  s.add_dependency('harmony')
 
+  s.add_development_dependency('harmony')
   s.add_development_dependency('shoulda')
   s.add_development_dependency('redgreen')
   s.add_development_dependency('rack-test')

--- a/javascript_features.gemspec
+++ b/javascript_features.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = 'javascript_features'
-  s.version = '1.0.1'
-  s.date = '2011-03-15'
+  s.version = '1.0.1.reevoo'
+  s.date = '2011-05-24'
 
   s.authors = ['George Brocklehurst']
   s.email = 'george.brocklehurst@gmail.com'

--- a/lib/javascript_features/test_case.rb
+++ b/lib/javascript_features/test_case.rb
@@ -1,5 +1,10 @@
 require 'active_support/test_case'
-require 'harmony'
+
+begin
+  require 'harmony'
+rescue LoadError
+  raise 'You must gem install harmony to use javascript-features test case'
+end
 
 module JavascriptFeatures
   class TestCase < ::ActiveSupport::TestCase


### PR DESCRIPTION
We had trouble compiling johnson on live when deploying bumblebee, this looked like the simplest fix for us.
Since you can specify test dependancies in rubygems we had to remove it, another option would be to make a new javascript-features-test gem.
