### PR TITLE
Don't open the file, just to check the mtime.

### DIFF
--- a/lib/javascript_features/compiler.rb
+++ b/lib/javascript_features/compiler.rb
@@ -14,7 +14,7 @@ module JavascriptFeatures
     end
 
     def self.package_modified_time(package = 'main')
-      files_for_package(package).map{|f| File.new(f).mtime }.max
+      files_for_package(package).map{|f| File.mtime(f) }.max
     end
 
   private


### PR DESCRIPTION
This was leaving file handles all over the show, and I was getting too many open files errors at the OS level when the GC failed to kick in soon enough.

This just checks the mtime without opening the file for read.
